### PR TITLE
Fixed bug with AuthToken and Verifier not being encoded.

### DIFF
--- a/TweetStation/Utilities/OAuthAuthorizer.cs
+++ b/TweetStation/Utilities/OAuthAuthorizer.cs
@@ -188,8 +188,8 @@ namespace TweetStation
 				{ "oauth_version", "1.0" }};
 			var content = "";
 			if (xAuthUsername == null){
-				headers.Add ("oauth_token", AuthorizationToken);
-				headers.Add ("oauth_verifier", AuthorizationVerifier);
+				headers.Add ("oauth_token", OAuth.PercentEncode (AuthorizationToken));
+				headers.Add ("oauth_verifier", OAuth.PercentEncode (AuthorizationVerifier));
 			} else {
 				headers.Add ("x_auth_username", OAuth.PercentEncode (xAuthUsername));
 				headers.Add ("x_auth_password", OAuth.PercentEncode (xAuthPassword));


### PR DESCRIPTION
Fixed bug with AuthToken and Verifier not being encoded. DotNetOpenAuth does a split on the "=" character so it was causing an error. 

9 hours to track down (gotta love OAuth), but still way less time then it would take to recreate the excellent code that is TweetStation. Not to mention being able to program for the iPhone in C# also blows my mind, so THANK YOU!
